### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/src/Docnet.Core/Docnet.Core.csproj
+++ b/src/Docnet.Core/Docnet.Core.csproj
@@ -16,7 +16,15 @@
     <RepositoryUrl>https://github.com/GowenGit/docnet</RepositoryUrl>
     <PackageTags>PDF; Reader; netstandard; PDFium; JPEG; JPG</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/GowenGit/docnet/master/assets/icon.png</PackageIconUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <Content Include="runtimes/**" PackagePath="runtimes" Visible="true" />


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
