### PR TITLE
Capture LoadDocument error code with DocnetLoadDocumentException

### DIFF
--- a/src/Docnet.Core/Bindings/DocumentWrapper.cs
+++ b/src/Docnet.Core/Bindings/DocumentWrapper.cs
@@ -16,7 +16,7 @@ namespace Docnet.Core.Bindings
 
             if (Instance == null)
             {
-                throw new DocnetException("unable to open the document");
+                throw new DocnetLoadDocumentException("unable to open the document", fpdf_view.FPDF_GetLastError());
             }
         }
 
@@ -30,7 +30,7 @@ namespace Docnet.Core.Bindings
 
             if (Instance == null)
             {
-                throw new DocnetException("unable to open the document");
+                throw new DocnetLoadDocumentException("unable to open the document", fpdf_view.FPDF_GetLastError());
             }
         }
 
@@ -40,7 +40,7 @@ namespace Docnet.Core.Bindings
 
             if (Instance == null)
             {
-                throw new DocnetException("unable to open the document");
+                throw new DocnetLoadDocumentException("unable to open the document");
             }
         }
 

--- a/src/Docnet.Core/DocLib.cs
+++ b/src/Docnet.Core/DocLib.cs
@@ -4,6 +4,7 @@ using Docnet.Core.Editors;
 using Docnet.Core.Models;
 using Docnet.Core.Readers;
 using Docnet.Core.Validation;
+using Docnet.Core.Exceptions;
 
 // ReSharper disable ParameterOnlyUsedForPreconditionCheck.Local
 namespace Docnet.Core
@@ -165,28 +166,7 @@ namespace Docnet.Core
             lock (Lock)
             {
                 var code = fpdf_view.FPDF_GetLastError();
-
-                switch (code)
-                {
-                    case 0:
-                        return "no error";
-                    case 1:
-                        return "unknown error";
-                    case 2:
-                        return "file not found or could not be opened";
-                    case 3:
-                        return "file not in PDF format or corrupted";
-                    case 4:
-                        return "password required or incorrect password";
-                    case 5:
-                        return "unsupported security scheme";
-                    case 6:
-                        return "page not found or content error";
-                    case 1001:
-                        return "the requested operation cannot be completed due to a license restrictions";
-                    default:
-                        return "unknown error";
-                }
+                return LastError.ErrorCodePhrase(code);
             }
         }
 

--- a/src/Docnet.Core/Exceptions/DocnetLoadDocumentException.cs
+++ b/src/Docnet.Core/Exceptions/DocnetLoadDocumentException.cs
@@ -1,0 +1,29 @@
+
+#pragma warning disable CA2237
+
+using System;
+
+namespace Docnet.Core.Exceptions
+{
+    public class DocnetLoadDocumentException : DocnetException
+    {
+        public uint ErrorCode { get; set; } = 1;
+
+        public DocnetLoadDocumentException(string message) : base(message) { }
+
+        public DocnetLoadDocumentException(string message, uint errorCode) : base(DecorateMessage(message, errorCode))
+        {
+            ErrorCode = errorCode;
+        }
+
+        public DocnetLoadDocumentException(string message, uint errorCode, Exception innerException) : base(DecorateMessage(message, errorCode), innerException)
+        {
+            ErrorCode = errorCode;
+        }
+
+        private static string DecorateMessage(string message, uint errorCode)
+        {
+            return $"{message}: ErrorCode={errorCode}, ReasonPhrase={LastError.ErrorCodePhrase(errorCode)}";
+        }
+    }
+}

--- a/src/Docnet.Core/Exceptions/LastError.cs
+++ b/src/Docnet.Core/Exceptions/LastError.cs
@@ -1,0 +1,31 @@
+
+namespace Docnet.Core.Exceptions
+{
+    internal static class LastError
+    {
+        internal static string ErrorCodePhrase(uint errorCode)
+        {
+            switch (errorCode)
+            {
+                case 0:
+                    return "no error";
+                case 1:
+                    return "unknown error";
+                case 2:
+                    return "file not found or could not be opened";
+                case 3:
+                    return "file not in PDF format or corrupted";
+                case 4:
+                    return "password required or incorrect password";
+                case 5:
+                    return "unsupported security scheme";
+                case 6:
+                    return "page not found or content error";
+                case 1001:
+                    return "the requested operation cannot be completed due to a license restrictions";
+                default:
+                    return "unknown error";
+            }
+        }
+    }
+}


### PR DESCRIPTION
I believe that FPDF_GetLastError can only be safely called after FPDF_LoadDocument while holding the Lock, otherwise a race condition may arise.

To capture and pass the error code a new DocnetLoadDocumentException is introduced. The name of the exception was chosen because it seems FPDF_GetLastError is only relevant after calls to FPDF_LoadDocument and other LoadDocument variants.

DocLib.GetLastError is kept because it it public interface, and perhaps a major version increment is needed to change anything about it. 
 