### PR TITLE
Add public byte[] Merge(byte[] fileOne, ICollection<byte[]> files) me…

### DIFF
--- a/src/Docnet.Core/DocLib.cs
+++ b/src/Docnet.Core/DocLib.cs
@@ -97,15 +97,16 @@ namespace Docnet.Core
         }
 
         /// <inheritdoc />
-        public byte[] Merge(byte[] fileOne, ICollection<byte[]> files)
+        public byte[] Merge(IList<byte[]> files)
         {
-            Validator.CheckBytesNullOrZero(fileOne, nameof(fileOne));
+            Validator.CheckCollectionNotEmpty(files, nameof(files));
+
             foreach (var file in files)
             {
                 Validator.CheckBytesNullOrZero(file, nameof(files));
             }
 
-            return _editor.Merge(fileOne, files);
+            return _editor.Merge(files);
         }
 
         /// <inheritdoc />

--- a/src/Docnet.Core/DocLib.cs
+++ b/src/Docnet.Core/DocLib.cs
@@ -97,6 +97,18 @@ namespace Docnet.Core
         }
 
         /// <inheritdoc />
+        public byte[] Merge(byte[] fileOne, ICollection<byte[]> files)
+        {
+            Validator.CheckBytesNullOrZero(fileOne, nameof(fileOne));
+            foreach (var file in files)
+            {
+                Validator.CheckBytesNullOrZero(file, nameof(files));
+            }
+
+            return _editor.Merge(fileOne, files);
+        }
+
+        /// <inheritdoc />
         public byte[] Split(string filePath, int pageFromIndex, int pageToIndex)
         {
             Validator.CheckFilePathNotNull(filePath, nameof(filePath));

--- a/src/Docnet.Core/Editors/DocEditor.cs
+++ b/src/Docnet.Core/Editors/DocEditor.cs
@@ -60,11 +60,11 @@ namespace Docnet.Core.Editors
             }
         }
 
-        private static byte[] Merge(DocumentWrapper docOneWrapper, ICollection<DocumentWrapper> docTwoWrappers)
+        private static byte[] Merge(DocumentWrapper docOneWrapper, ICollection<DocumentWrapper> docWrappers)
         {
             using (var stream = new MemoryStream())
             {
-                foreach (DocumentWrapper documentWrapper in docTwoWrappers)
+                foreach (DocumentWrapper documentWrapper in docWrappers)
                 {
                     var pageCountOne = fpdf_view.FPDF_GetPageCount(docOneWrapper.Instance);
 

--- a/src/Docnet.Core/Editors/DocEditor.cs
+++ b/src/Docnet.Core/Editors/DocEditor.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Docnet.Core.Bindings;
@@ -28,6 +29,58 @@ namespace Docnet.Core.Editors
                 {
                     return Merge(docOneWrapper, docTwoWrapper);
                 }
+            }
+        }
+
+        public byte[] Merge(byte[] fileOne, ICollection<byte[]> files)
+        {
+            lock (DocLib.Lock)
+            {
+                using (var docOneWrapper = new DocumentWrapper(fileOne, null))
+                {
+                    var documentWrappers = new List<DocumentWrapper>();
+
+                    try
+                    {
+                        foreach (var file in files)
+                        {
+                            documentWrappers.Add(new DocumentWrapper(file, null));
+                        }
+
+                        return Merge(docOneWrapper, documentWrappers);
+                    }
+                    finally
+                    {
+                        foreach (DocumentWrapper documentWrapper in documentWrappers)
+                        {
+                            documentWrapper.Dispose();
+                        }
+                    }
+                }
+            }
+        }
+
+        private static byte[] Merge(DocumentWrapper docOneWrapper, ICollection<DocumentWrapper> docTwoWrappers)
+        {
+            using (var stream = new MemoryStream())
+            {
+                foreach (DocumentWrapper documentWrapper in docTwoWrappers)
+                {
+                    var pageCountOne = fpdf_view.FPDF_GetPageCount(docOneWrapper.Instance);
+
+                    var success = fpdf_ppo.FPDF_ImportPages(
+                                      docOneWrapper.Instance,
+                                      documentWrapper.Instance,
+                                      null,
+                                      pageCountOne) == 1;
+
+                    if (!success)
+                    {
+                        throw new DocnetException("failed to merge files");
+                    }
+                }
+
+                return GetBytes(stream, docOneWrapper);
             }
         }
 

--- a/src/Docnet.Core/Editors/IDocEditor.cs
+++ b/src/Docnet.Core/Editors/IDocEditor.cs
@@ -8,7 +8,7 @@ namespace Docnet.Core.Editors
 
         byte[] Merge(byte[] fileOne, byte[] fileTwo);
 
-        byte[] Merge(byte[] fileOne, ICollection<byte[]> files);
+        byte[] Merge(IList<byte[]> files);
 
         byte[] Split(string filePath, int pageFromIndex, int pageToIndex);
 

--- a/src/Docnet.Core/Editors/IDocEditor.cs
+++ b/src/Docnet.Core/Editors/IDocEditor.cs
@@ -8,6 +8,8 @@ namespace Docnet.Core.Editors
 
         byte[] Merge(byte[] fileOne, byte[] fileTwo);
 
+        byte[] Merge(byte[] fileOne, ICollection<byte[]> files);
+
         byte[] Split(string filePath, int pageFromIndex, int pageToIndex);
 
         byte[] Split(byte[] bytes, int pageFromIndex, int pageToIndex);

--- a/src/Docnet.Core/IDocLib.cs
+++ b/src/Docnet.Core/IDocLib.cs
@@ -65,6 +65,14 @@ namespace Docnet.Core
         byte[] Merge(byte[] fileOne, byte[] fileTwo);
 
         /// <summary>
+        /// Merge documents into one.
+        /// </summary>
+        /// <param name="fileOne">File one bytes.</param>
+        /// <param name="files">Files to merge to fileOne.</param>
+        /// <returns>New file bytes.</returns>
+        byte[] Merge(byte[] fileOne, ICollection<byte[]> files);
+
+        /// <summary>
         /// Split a range of pages into a separate document.
         /// </summary>
         /// <param name="filePath">Full file path.</param>

--- a/src/Docnet.Core/IDocLib.cs
+++ b/src/Docnet.Core/IDocLib.cs
@@ -67,10 +67,9 @@ namespace Docnet.Core
         /// <summary>
         /// Merge documents into one.
         /// </summary>
-        /// <param name="fileOne">File one bytes.</param>
         /// <param name="files">Files to merge to fileOne.</param>
         /// <returns>New file bytes.</returns>
-        byte[] Merge(byte[] fileOne, ICollection<byte[]> files);
+        byte[] Merge(IList<byte[]> files);
 
         /// <summary>
         /// Split a range of pages into a separate document.

--- a/src/Docnet.Core/Validation/Validator.cs
+++ b/src/Docnet.Core/Validation/Validator.cs
@@ -1,9 +1,18 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Docnet.Core.Validation
 {
     internal static class Validator
     {
+        public static void CheckCollectionNotEmpty<T>(ICollection<T> enumerable, string name)
+        {
+            if (enumerable.Count <= 0)
+            {
+                throw new ArgumentException("Collection can't be empty", name);
+            }
+        }
+
         public static void CheckFilePathNotNull(string filePath, string name)
         {
             if (filePath == null)

--- a/src/Docnet.Tests.Integration/MergeTests.cs
+++ b/src/Docnet.Tests.Integration/MergeTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using Docnet.Core.Models;
 using Docnet.Tests.Integration.Utils;
@@ -79,6 +80,28 @@ namespace Docnet.Tests.Integration
             var bytesTwo = File.ReadAllBytes(fileTwo);
 
             var mergedBytes = _fixture.Lib.Merge(bytesOne, bytesTwo);
+
+            using (var reader = _fixture.Lib.GetDocReader(mergedBytes, new PageDimensions(10, 10)))
+            {
+                Assert.Equal(expectedPageCount, reader.GetPageCount());
+            }
+        }
+
+        [Theory]
+        [InlineData("Docs/simple_0.pdf", "Docs/simple_1.pdf", "Docs/simple_2.pdf", 34)]
+        [InlineData("Docs/simple_0.pdf", "Docs/simple_2.pdf", "Docs/simple_3.pdf", 31)]
+        [InlineData("Docs/simple_1.pdf", "Docs/simple_3.pdf", "Docs/simple_4.pdf", 8)]
+        public void Merge_WhenCalledWithBytes_ShouldMergeThreeDocs(string fileOne, string fileTwo, string fileThree, int expectedPageCount)
+        {
+            var bytesOne = File.ReadAllBytes(fileOne);
+
+            var byteFiles = new List<byte[]>
+            {
+                File.ReadAllBytes(fileTwo),
+                File.ReadAllBytes(fileThree),
+            };
+
+            var mergedBytes = _fixture.Lib.Merge(bytesOne, byteFiles);
 
             using (var reader = _fixture.Lib.GetDocReader(mergedBytes, new PageDimensions(10, 10)))
             {

--- a/src/Docnet.Tests.Integration/MergeTests.cs
+++ b/src/Docnet.Tests.Integration/MergeTests.cs
@@ -30,6 +30,18 @@ namespace Docnet.Tests.Integration
         }
 
         [Fact]
+        public void Merge_WhenCalledWithEnptyByteArray_ShouldThrow()
+        {
+            Assert.Throws<ArgumentException>(() => _fixture.Lib.Merge(new List<byte[]>()));
+        }
+
+        [Fact]
+        public void Merge_WhenCalledWithByteArrayWithFirstNullBytes_ShouldThrow()
+        {
+            Assert.Throws<ArgumentNullException>(() => _fixture.Lib.Merge(new List<byte[]> { Array.Empty<byte>() }));
+        }
+
+        [Fact]
         public void Merge_WhenCalledWithFirstEmptyBytes_ShouldThrow()
         {
             Assert.Throws<ArgumentNullException>(() => _fixture.Lib.Merge(Array.Empty<byte>(), new byte[1]));
@@ -93,15 +105,14 @@ namespace Docnet.Tests.Integration
         [InlineData("Docs/simple_1.pdf", "Docs/simple_3.pdf", "Docs/simple_4.pdf", 8)]
         public void Merge_WhenCalledWithBytes_ShouldMergeThreeDocs(string fileOne, string fileTwo, string fileThree, int expectedPageCount)
         {
-            var bytesOne = File.ReadAllBytes(fileOne);
-
             var byteFiles = new List<byte[]>
             {
+                File.ReadAllBytes(fileOne),
                 File.ReadAllBytes(fileTwo),
                 File.ReadAllBytes(fileThree),
             };
 
-            var mergedBytes = _fixture.Lib.Merge(bytesOne, byteFiles);
+            var mergedBytes = _fixture.Lib.Merge(byteFiles);
 
             using (var reader = _fixture.Lib.GetDocReader(mergedBytes, new PageDimensions(10, 10)))
             {

--- a/src/Docnet.Tests.Integration/MergeTests.cs
+++ b/src/Docnet.Tests.Integration/MergeTests.cs
@@ -43,7 +43,7 @@ namespace Docnet.Tests.Integration
         [Fact]
         public void Merge_WhenCalledWithSecondNullBytes_ShouldThrow()
         {
-            Assert.Throws<ArgumentNullException>(() => _fixture.Lib.Merge(new byte[1], null));
+            Assert.Throws<ArgumentNullException>(() => _fixture.Lib.Merge(new byte[1], (byte[])null));
         }
 
         [Fact]


### PR DESCRIPTION
I have added a `public byte[] Merge(byte[] fileOne, ICollection<byte[]> files)` allowing to merge more than 2 files at once.

Performance are much better because the time taken increases linearly as the number of file increases. Checkout [this Google spreadsheet](https://docs.google.com/spreadsheets/d/1tBGVH8x43DpIovysLUqE7tl9yTvGcCIO6osfTP2Npo8/edit?usp=sharing) for the detailed results with the same input PDFs as the one I mentioned in #41.

I would be glad to change my code accordingly to your remarks.
I hope you'll have some time to review my code, merge it to master and deploy a new version of Docnet.core cause I need it.

Fixes #41.

Thanks
Yanal
