### PR TITLE
Readable exception when merge is failed

### DIFF
--- a/src/Docnet.Core/Exceptions/DocnetLoadDocumentsException.cs
+++ b/src/Docnet.Core/Exceptions/DocnetLoadDocumentsException.cs
@@ -1,0 +1,25 @@
+namespace Docnet.Core.Exceptions
+{
+    public class DocnetLoadDocumentsException : DocnetException
+    {
+        public DocnetLoadDocumentError[] FilesWithErrors { get; }
+
+        public DocnetLoadDocumentsException(string message, DocnetLoadDocumentError[] loadErrors) : base(message)
+        {
+            FilesWithErrors = loadErrors;
+        }
+    }
+
+    public class DocnetLoadDocumentError
+    {
+        public int DocumentIndex { get; }
+
+        public DocnetLoadDocumentException Exception { get; }
+
+        public DocnetLoadDocumentError(int documentIndex, DocnetLoadDocumentException exception)
+        {
+            DocumentIndex = documentIndex;
+            Exception = exception;
+        }
+    }
+}


### PR DESCRIPTION
When the merge is executing with some amount of files, it is hard to understand which files caused the merge error. Added returning exception with a list of errors to determine such files.