### PR TITLE
Disable DocReader methods when disposed

### DIFF
--- a/src/Docnet.Core/Readers/DocReader.cs
+++ b/src/Docnet.Core/Readers/DocReader.cs
@@ -1,3 +1,4 @@
+using System;
 using Docnet.Core.Bindings;
 using Docnet.Core.Exceptions;
 using Docnet.Core.Models;
@@ -9,6 +10,8 @@ namespace Docnet.Core.Readers
     {
         private readonly DocumentWrapper _docWrapper;
         private readonly PageDimensions _dimensions;
+
+        private bool _disposed;
 
         public DocReader(string filePath, string password, PageDimensions dimensions)
         {
@@ -33,6 +36,11 @@ namespace Docnet.Core.Readers
         /// <inheritdoc />
         public PdfVersion GetPdfVersion()
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException("DocReader has been disposed.");
+            }
+
             var version = 0;
 
             lock (DocLib.Lock)
@@ -51,6 +59,11 @@ namespace Docnet.Core.Readers
         /// <inheritdoc />
         public int GetPageCount()
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException("DocReader has been disposed.");
+            }
+
             lock (DocLib.Lock)
             {
                 return fpdf_view.FPDF_GetPageCount(_docWrapper.Instance);
@@ -60,6 +73,11 @@ namespace Docnet.Core.Readers
         /// <inheritdoc />
         public IPageReader GetPageReader(int pageIndex)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException("DocReader has been disposed.");
+            }
+
             return new PageReader(_docWrapper, pageIndex, _dimensions);
         }
 
@@ -68,6 +86,7 @@ namespace Docnet.Core.Readers
             lock (DocLib.Lock)
             {
                 _docWrapper?.Dispose();
+                _disposed = true;
             }
         }
     }

--- a/src/Docnet.Tests.Integration/DocReaderTests.cs
+++ b/src/Docnet.Tests.Integration/DocReaderTests.cs
@@ -93,5 +93,41 @@ namespace Docnet.Tests.Integration
                 Assert.Equal(expectedVersion, version.Number);
             }
         }
+
+        [Fact]
+        public void GetPdfVersion_WhenCalledWhenDisposed_ShouldThrow()
+        {
+            var reader = _fixture.GetDocReader(Input.FromFile, "Docs/simple_0.pdf", null, 10, 10);
+            reader.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                reader.GetPdfVersion();
+            });
+        }
+
+        [Fact]
+        public void GetPageCount_WhenCalledWhenDisposed_ShouldThrow()
+        {
+            var reader = _fixture.GetDocReader(Input.FromFile, "Docs/simple_0.pdf", null, 10, 10);
+            reader.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                reader.GetPageCount();
+            });
+        }
+
+        [Fact]
+        public void GetPageReader_WhenCalledWhenDisposed_ShouldThrow()
+        {
+            var reader = _fixture.GetDocReader(Input.FromFile, "Docs/simple_0.pdf", null, 10, 10);
+            reader.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                reader.GetPageReader(0);
+            });
+        }
     }
 }


### PR DESCRIPTION
Before this change it was possible to use the DocReader methods when the reader was already disposed. This caused confusing behavior like PageCount being 0 even when it should be something else and there was no error or exception indicating that something was wrong.

Now using the methods has been prevented by checking for disposed flag and throwing exception in that case.