### PR TITLE
Mac ARM compatibility

### DIFF
--- a/src/Docnet.Core/build/net45/Docnet.Core.targets
+++ b/src/Docnet.Core/build/net45/Docnet.Core.targets
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <DocnetRuntime Condition=" '$(DocnetRuntime)' == '' AND '$([MSBuild]::IsOsPlatform(OSX))' ">osx</DocnetRuntime>
+    <DocnetRuntime Condition=" '$(DocnetRuntime)' == '' AND '$([MSBuild]::IsOsPlatform(OSX))' AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'ARM64' ">osx-arm64</DocnetRuntime>
+    <DocnetRuntime Condition=" '$(DocnetRuntime)' == '' AND '$([MSBuild]::IsOsPlatform(OSX))' AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'x64'">osx-x64</DocnetRuntime>
     <DocnetRuntime Condition=" '$(DocnetRuntime)' == '' AND '$([MSBuild]::IsOsPlatform(Linux))' ">linux</DocnetRuntime>
     <DocnetRuntime Condition=" '$(DocnetRuntime)' == '' AND ('$(Prefer32Bit)' == 'true' OR '$(PlatformTarget)' == 'x86') AND '$([MSBuild]::IsOsPlatform(Windows))' ">win-x86</DocnetRuntime>
     <DocnetRuntime Condition=" '$(DocnetRuntime)' == '' ">win-x64</DocnetRuntime>


### PR DESCRIPTION
Fixes # .
Adding build target for mac arm 64 support

`<DocnetRuntime Condition=" '$(DocnetRuntime)' == '' AND '$([MSBuild]::IsOsPlatform(OSX))' AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'ARM64' ">osx-arm64</DocnetRuntime>
`

