### PR TITLE
Improving the Merge for Multiple Files.

### DIFF
--- a/src/Docnet.Core/Editors/DocEditor.cs
+++ b/src/Docnet.Core/Editors/DocEditor.cs
@@ -1,279 +1,283 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
 using Docnet.Core.Bindings;
 using Docnet.Core.Exceptions;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
 namespace Docnet.Core.Editors
 {
-    internal class DocEditor : IDocEditor
+  internal class DocEditor : IDocEditor
+  {
+    public byte[] Merge(string fileOne, string fileTwo)
     {
-        public byte[] Merge(string fileOne, string fileTwo)
+      lock (DocLib.Lock)
+      {
+        using (var docOneWrapper = new DocumentWrapper(fileOne, null))
+        using (var docTwoWrapper = new DocumentWrapper(fileTwo, null))
         {
-            lock (DocLib.Lock)
-            {
-                using (var docOneWrapper = new DocumentWrapper(fileOne, null))
-                using (var docTwoWrapper = new DocumentWrapper(fileTwo, null))
-                {
-                    return Merge(docOneWrapper, docTwoWrapper);
-                }
-            }
+          return Merge(docOneWrapper, docTwoWrapper);
         }
+      }
+    }
 
-        public byte[] Merge(byte[] fileOne, byte[] fileTwo)
+    public byte[] Merge(byte[] fileOne, byte[] fileTwo)
+    {
+      lock (DocLib.Lock)
+      {
+        using (var docOneWrapper = new DocumentWrapper(fileOne, null))
+        using (var docTwoWrapper = new DocumentWrapper(fileTwo, null))
         {
-            lock (DocLib.Lock)
-            {
-                using (var docOneWrapper = new DocumentWrapper(fileOne, null))
-                using (var docTwoWrapper = new DocumentWrapper(fileTwo, null))
-                {
-                    return Merge(docOneWrapper, docTwoWrapper);
-                }
-            }
+          return Merge(docOneWrapper, docTwoWrapper);
         }
+      }
+    }
 
-        public byte[] Merge(IReadOnlyList<byte[]> files)
+    public byte[] Merge(IReadOnlyList<byte[]> files)
+    {
+      using (var newWrapper = new DocumentWrapper(fpdf_edit.FPDF_CreateNewDocument()))
+      {
+        lock (DocLib.Lock)
         {
-            lock (DocLib.Lock)
-            {
-                var documentWrappers = OpenDocuments(files);
+          var documentWrappers = OpenDocuments(files);
+          documentWrappers = documentWrappers.Prepend(newWrapper).ToArray();
 
-                try
-                {
-                    return Merge(documentWrappers);
-                }
-                finally
-                {
-                    foreach (DocumentWrapper documentWrapper in documentWrappers)
-                    {
-                        documentWrapper.Dispose();
-                    }
-                }
+          try
+          {
+            return Merge(documentWrappers);
+          }
+          finally
+          {
+            foreach (DocumentWrapper documentWrapper in documentWrappers)
+            {
+              documentWrapper.Dispose();
             }
+          }
         }
+      }
+    }
 
-        private static DocumentWrapper[] OpenDocuments(IReadOnlyList<byte[]> files)
+    private static DocumentWrapper[] OpenDocuments(IReadOnlyList<byte[]> files)
+    {
+      var documentWrappers = new List<DocumentWrapper>();
+      var documentLoadExceptions = new List<DocnetLoadDocumentError>();
+
+      for (var i = 0; i < files.Count; i++)
+      {
+        try
         {
-            var documentWrappers = new List<DocumentWrapper>();
-            var documentLoadExceptions = new List<DocnetLoadDocumentError>();
+          var wrapper = new DocumentWrapper(files[i], null);
 
-            for (var i = 0; i < files.Count; i++)
-            {
-                try
-                {
-                    var wrapper = new DocumentWrapper(files[i], null);
-
-                    documentWrappers.Add(wrapper);
-                }
-                catch (DocnetLoadDocumentException e)
-                {
-                    documentLoadExceptions.Add(new DocnetLoadDocumentError(i, e));
-                }
-            }
-
-            if (documentLoadExceptions.Count <= 0)
-            {
-                return documentWrappers.ToArray();
-            }
-
-            foreach (var documentWrapper in documentWrappers)
-            {
-                documentWrapper.Dispose();
-            }
-
-            throw new DocnetLoadDocumentsException("unable to open one or more documents", documentLoadExceptions.ToArray());
+          documentWrappers.Add(wrapper);
         }
-
-        private static byte[] Merge(IList<DocumentWrapper> docWrappers)
+        catch (DocnetLoadDocumentException e)
         {
-            var docOneWrapper = docWrappers[0];
-            using (var stream = new MemoryStream())
-            {
-                if (docWrappers.Count > 1)
-                {
-                    for (int i = 1; i < docWrappers.Count; i++)
-                    {
-                        var documentWrapper = docWrappers[i];
-                        var pageCountOne = fpdf_view.FPDF_GetPageCount(docOneWrapper.Instance);
-
-                        var success = fpdf_ppo.FPDF_ImportPages(
-                                          docOneWrapper.Instance,
-                                          documentWrapper.Instance,
-                                          null,
-                                          pageCountOne) == 1;
-
-                        if (!success)
-                        {
-                            throw new DocnetException("failed to merge files");
-                        }
-                    }
-                }
-
-                return GetBytes(stream, docOneWrapper);
-            }
+          documentLoadExceptions.Add(new DocnetLoadDocumentError(i, e));
         }
+      }
 
-        private static byte[] Merge(DocumentWrapper docOneWrapper, DocumentWrapper docTwoWrapper)
+      if (documentLoadExceptions.Count <= 0)
+      {
+        return documentWrappers.ToArray();
+      }
+
+      foreach (var documentWrapper in documentWrappers)
+      {
+        documentWrapper.Dispose();
+      }
+
+      throw new DocnetLoadDocumentsException("unable to open one or more documents", documentLoadExceptions.ToArray());
+    }
+
+    private static byte[] Merge(IList<DocumentWrapper> docWrappers)
+    {
+      var docOneWrapper = docWrappers[0];
+      using (var stream = new MemoryStream())
+      {
+        if (docWrappers.Count > 1)
         {
-            using (var stream = new MemoryStream())
-            {
-                var pageCountOne = fpdf_view.FPDF_GetPageCount(docOneWrapper.Instance);
+          for (int i = 1; i < docWrappers.Count; i++)
+          {
+            var documentWrapper = docWrappers[i];
+            var pageCountOne = fpdf_view.FPDF_GetPageCount(docOneWrapper.Instance);
 
-                var success = fpdf_ppo.FPDF_ImportPages(
-                                  docOneWrapper.Instance,
-                                  docTwoWrapper.Instance,
-                                  null,
-                                  pageCountOne) == 1;
-
-                if (!success)
-                {
-                    throw new DocnetException("failed to merge files");
-                }
-
-                return GetBytes(stream, docOneWrapper);
-            }
-        }
-
-        public byte[] Split(string filePath, int pageFromIndex, int pageToIndex)
-        {
-            lock (DocLib.Lock)
-            {
-                using (var srcWrapper = new DocumentWrapper(filePath, null))
-                {
-                    return Split(srcWrapper, pageFromIndex, pageToIndex);
-                }
-            }
-        }
-
-        public byte[] Split(byte[] bytes, int pageFromIndex, int pageToIndex)
-        {
-            lock (DocLib.Lock)
-            {
-                using (var srcWrapper = new DocumentWrapper(bytes, null))
-                {
-                    return Split(srcWrapper, pageFromIndex, pageToIndex);
-                }
-            }
-        }
-
-        public byte[] Split(string filePath, string pageRange)
-        {
-            lock (DocLib.Lock)
-            {
-                using (var srcWrapper = new DocumentWrapper(filePath, null))
-                {
-                    return Split(srcWrapper, pageRange);
-                }
-            }
-        }
-
-        public byte[] Split(byte[] bytes, string pageRange)
-        {
-            lock (DocLib.Lock)
-            {
-                using (var srcWrapper = new DocumentWrapper(bytes, null))
-                {
-                    return Split(srcWrapper, pageRange);
-                }
-            }
-        }
-
-        private static byte[] Split(DocumentWrapper srcWrapper, int pageFromIndex, int pageToIndex)
-        {
-            return Split(srcWrapper, $"{pageFromIndex + 1} - {pageToIndex + 1}");
-        }
-
-        private static byte[] Split(DocumentWrapper srcWrapper, string pageRange)
-        {
-            using (var newWrapper = new DocumentWrapper(fpdf_edit.FPDF_CreateNewDocument()))
-            using (var stream = new MemoryStream())
-            {
-                var success = fpdf_ppo.FPDF_ImportPages(
-                                  newWrapper.Instance,
-                                  srcWrapper.Instance,
-                                  pageRange,
-                                  0) == 1;
-
-                if (!success)
-                {
-                    throw new DocnetException("failed to split file");
-                }
-
-                return GetBytes(stream, newWrapper);
-            }
-        }
-
-        public byte[] Unlock(string filePath, string password)
-        {
-            lock (DocLib.Lock)
-            {
-                using (var docWrapper = new DocumentWrapper(filePath, password))
-                {
-                    return Unlock(docWrapper);
-                }
-            }
-        }
-
-        public byte[] Unlock(byte[] bytes, string password)
-        {
-            lock (DocLib.Lock)
-            {
-                using (var docWrapper = new DocumentWrapper(bytes, password))
-                {
-                    return Unlock(docWrapper);
-                }
-            }
-        }
-
-        public byte[] JpegToPdf(IReadOnlyList<JpegImage> files)
-        {
-            lock (DocLib.Lock)
-            {
-                using (var newWrapper = new DocumentWrapper(fpdf_edit.FPDF_CreateNewDocument()))
-                using (var outStream = new MemoryStream())
-                {
-                    var index = 0;
-
-                    foreach (var image in files)
-                    {
-                        using (var stream = new MemoryStream(image.Bytes))
-                        {
-                            var page = fpdf_edit.FPDFPageNew(newWrapper.Instance, index, image.Width, image.Height);
-                            var imageObj = fpdf_edit.FPDFPageObjNewImageObj(newWrapper.Instance);
-
-                            fpdf_custom_edit.FPDFImageObjLoadJpegFile(page, 1, imageObj, FileHandle.FromStream(stream, image.Bytes.Length));
-                            fpdf_edit.FPDFImageObjSetMatrix(imageObj, image.Width, 0, 0, image.Height, 0, 0);
-                            fpdf_edit.FPDFPageInsertObject(page, imageObj);
-                            fpdf_edit.FPDFPageGenerateContent(page);
-                            fpdf_view.FPDF_ClosePage(page);
-
-                            index++;
-                        }
-                    }
-
-                    return GetBytes(outStream, newWrapper);
-                }
-            }
-        }
-
-        private static byte[] Unlock(DocumentWrapper docWrapper)
-        {
-            using (var stream = new MemoryStream())
-            {
-                return GetBytes(stream, docWrapper);
-            }
-        }
-
-        private static byte[] GetBytes(MemoryStream stream, DocumentWrapper docWrapper)
-        {
-            var success = fpdf_save.FPDF_SaveAsCopy(docWrapper.Instance, stream);
+            var success = fpdf_ppo.FPDF_ImportPages(
+                              docOneWrapper.Instance,
+                              documentWrapper.Instance,
+                              null,
+                              pageCountOne) == 1;
 
             if (!success)
             {
-                throw new DocnetException("failed to unlock the document");
+              throw new DocnetException("failed to merge files");
             }
-
-            return stream.ToArray();
+          }
         }
+
+        return GetBytes(stream, docOneWrapper);
+      }
     }
+
+    private static byte[] Merge(DocumentWrapper docOneWrapper, DocumentWrapper docTwoWrapper)
+    {
+      using (var stream = new MemoryStream())
+      {
+        var pageCountOne = fpdf_view.FPDF_GetPageCount(docOneWrapper.Instance);
+
+        var success = fpdf_ppo.FPDF_ImportPages(
+                          docOneWrapper.Instance,
+                          docTwoWrapper.Instance,
+                          null,
+                          pageCountOne) == 1;
+
+        if (!success)
+        {
+          throw new DocnetException("failed to merge files");
+        }
+
+        return GetBytes(stream, docOneWrapper);
+      }
+    }
+
+    public byte[] Split(string filePath, int pageFromIndex, int pageToIndex)
+    {
+      lock (DocLib.Lock)
+      {
+        using (var srcWrapper = new DocumentWrapper(filePath, null))
+        {
+          return Split(srcWrapper, pageFromIndex, pageToIndex);
+        }
+      }
+    }
+
+    public byte[] Split(byte[] bytes, int pageFromIndex, int pageToIndex)
+    {
+      lock (DocLib.Lock)
+      {
+        using (var srcWrapper = new DocumentWrapper(bytes, null))
+        {
+          return Split(srcWrapper, pageFromIndex, pageToIndex);
+        }
+      }
+    }
+
+    public byte[] Split(string filePath, string pageRange)
+    {
+      lock (DocLib.Lock)
+      {
+        using (var srcWrapper = new DocumentWrapper(filePath, null))
+        {
+          return Split(srcWrapper, pageRange);
+        }
+      }
+    }
+
+    public byte[] Split(byte[] bytes, string pageRange)
+    {
+      lock (DocLib.Lock)
+      {
+        using (var srcWrapper = new DocumentWrapper(bytes, null))
+        {
+          return Split(srcWrapper, pageRange);
+        }
+      }
+    }
+
+    private static byte[] Split(DocumentWrapper srcWrapper, int pageFromIndex, int pageToIndex)
+    {
+      return Split(srcWrapper, $"{pageFromIndex + 1} - {pageToIndex + 1}");
+    }
+
+    private static byte[] Split(DocumentWrapper srcWrapper, string pageRange)
+    {
+      using (var newWrapper = new DocumentWrapper(fpdf_edit.FPDF_CreateNewDocument()))
+      using (var stream = new MemoryStream())
+      {
+        var success = fpdf_ppo.FPDF_ImportPages(
+                          newWrapper.Instance,
+                          srcWrapper.Instance,
+                          pageRange,
+                          0) == 1;
+
+        if (!success)
+        {
+          throw new DocnetException("failed to split file");
+        }
+
+        return GetBytes(stream, newWrapper);
+      }
+    }
+
+    public byte[] Unlock(string filePath, string password)
+    {
+      lock (DocLib.Lock)
+      {
+        using (var docWrapper = new DocumentWrapper(filePath, password))
+        {
+          return Unlock(docWrapper);
+        }
+      }
+    }
+
+    public byte[] Unlock(byte[] bytes, string password)
+    {
+      lock (DocLib.Lock)
+      {
+        using (var docWrapper = new DocumentWrapper(bytes, password))
+        {
+          return Unlock(docWrapper);
+        }
+      }
+    }
+
+    public byte[] JpegToPdf(IReadOnlyList<JpegImage> files)
+    {
+      lock (DocLib.Lock)
+      {
+        using (var newWrapper = new DocumentWrapper(fpdf_edit.FPDF_CreateNewDocument()))
+        using (var outStream = new MemoryStream())
+        {
+          var index = 0;
+
+          foreach (var image in files)
+          {
+            using (var stream = new MemoryStream(image.Bytes))
+            {
+              var page = fpdf_edit.FPDFPageNew(newWrapper.Instance, index, image.Width, image.Height);
+              var imageObj = fpdf_edit.FPDFPageObjNewImageObj(newWrapper.Instance);
+
+              fpdf_custom_edit.FPDFImageObjLoadJpegFile(page, 1, imageObj, FileHandle.FromStream(stream, image.Bytes.Length));
+              fpdf_edit.FPDFImageObjSetMatrix(imageObj, image.Width, 0, 0, image.Height, 0, 0);
+              fpdf_edit.FPDFPageInsertObject(page, imageObj);
+              fpdf_edit.FPDFPageGenerateContent(page);
+              fpdf_view.FPDF_ClosePage(page);
+
+              index++;
+            }
+          }
+
+          return GetBytes(outStream, newWrapper);
+        }
+      }
+    }
+
+    private static byte[] Unlock(DocumentWrapper docWrapper)
+    {
+      using (var stream = new MemoryStream())
+      {
+        return GetBytes(stream, docWrapper);
+      }
+    }
+
+    private static byte[] GetBytes(MemoryStream stream, DocumentWrapper docWrapper)
+    {
+      var success = fpdf_save.FPDF_SaveAsCopy(docWrapper.Instance, stream);
+
+      if (!success)
+      {
+        throw new DocnetException("failed to unlock the document");
+      }
+
+      return stream.ToArray();
+    }
+  }
 }

--- a/src/Docnet.Core/Editors/DocEditor.cs
+++ b/src/Docnet.Core/Editors/DocEditor.cs
@@ -6,278 +6,280 @@ using System.Linq;
 
 namespace Docnet.Core.Editors
 {
-  internal class DocEditor : IDocEditor
-  {
-    public byte[] Merge(string fileOne, string fileTwo)
+    internal class DocEditor : IDocEditor
     {
-      lock (DocLib.Lock)
-      {
-        using (var docOneWrapper = new DocumentWrapper(fileOne, null))
-        using (var docTwoWrapper = new DocumentWrapper(fileTwo, null))
+        public byte[] Merge(string fileOne, string fileTwo)
         {
-          return Merge(docOneWrapper, docTwoWrapper);
-        }
-      }
-    }
-
-    public byte[] Merge(byte[] fileOne, byte[] fileTwo)
-    {
-      lock (DocLib.Lock)
-      {
-        using (var docOneWrapper = new DocumentWrapper(fileOne, null))
-        using (var docTwoWrapper = new DocumentWrapper(fileTwo, null))
-        {
-          return Merge(docOneWrapper, docTwoWrapper);
-        }
-      }
-    }
-
-    public byte[] Merge(IReadOnlyList<byte[]> files)
-    {
-      using (var newWrapper = new DocumentWrapper(fpdf_edit.FPDF_CreateNewDocument()))
-      {
-        lock (DocLib.Lock)
-        {
-          var documentWrappers = OpenDocuments(files);
-          documentWrappers = documentWrappers.Prepend(newWrapper).ToArray();
-
-          try
-          {
-            return Merge(documentWrappers);
-          }
-          finally
-          {
-            foreach (DocumentWrapper documentWrapper in documentWrappers)
+            lock (DocLib.Lock)
             {
-              documentWrapper.Dispose();
+                using (var docOneWrapper = new DocumentWrapper(fileOne, null))
+                using (var docTwoWrapper = new DocumentWrapper(fileTwo, null))
+                {
+                    return Merge(docOneWrapper, docTwoWrapper);
+                }
             }
-          }
         }
-      }
-    }
 
-    private static DocumentWrapper[] OpenDocuments(IReadOnlyList<byte[]> files)
-    {
-      var documentWrappers = new List<DocumentWrapper>();
-      var documentLoadExceptions = new List<DocnetLoadDocumentError>();
-
-      for (var i = 0; i < files.Count; i++)
-      {
-        try
+        public byte[] Merge(byte[] fileOne, byte[] fileTwo)
         {
-          var wrapper = new DocumentWrapper(files[i], null);
-
-          documentWrappers.Add(wrapper);
+            lock (DocLib.Lock)
+            {
+                using (var docOneWrapper = new DocumentWrapper(fileOne, null))
+                using (var docTwoWrapper = new DocumentWrapper(fileTwo, null))
+                {
+                    return Merge(docOneWrapper, docTwoWrapper);
+                }
+            }
         }
-        catch (DocnetLoadDocumentException e)
+
+        public byte[] Merge(IReadOnlyList<byte[]> files)
         {
-          documentLoadExceptions.Add(new DocnetLoadDocumentError(i, e));
+            using (var newWrapper = new DocumentWrapper(fpdf_edit.FPDF_CreateNewDocument()))
+            {
+                lock (DocLib.Lock)
+                {
+                    var documentWrappers = OpenDocuments(files);
+                    documentWrappers = documentWrappers.Prepend(newWrapper).ToArray();
+
+                    try
+                    {
+                        return Merge(documentWrappers);
+                    }
+                    finally
+                    {
+                        foreach (DocumentWrapper documentWrapper in documentWrappers)
+                        {
+                            documentWrapper.Dispose();
+                        }
+                    }
+                }
+            }
         }
-      }
 
-      if (documentLoadExceptions.Count <= 0)
-      {
-        return documentWrappers.ToArray();
-      }
-
-      foreach (var documentWrapper in documentWrappers)
-      {
-        documentWrapper.Dispose();
-      }
-
-      throw new DocnetLoadDocumentsException("unable to open one or more documents", documentLoadExceptions.ToArray());
-    }
-
-    private static byte[] Merge(IList<DocumentWrapper> docWrappers)
-    {
-      var docOneWrapper = docWrappers[0];
-      using (var stream = new MemoryStream())
-      {
-        if (docWrappers.Count > 1)
+        private static DocumentWrapper[] OpenDocuments(IReadOnlyList<byte[]> files)
         {
-          for (int i = 1; i < docWrappers.Count; i++)
-          {
-            var documentWrapper = docWrappers[i];
-            var pageCountOne = fpdf_view.FPDF_GetPageCount(docOneWrapper.Instance);
+            var documentWrappers = new List<DocumentWrapper>();
+            var documentLoadExceptions = new List<DocnetLoadDocumentError>();
 
-            var success = fpdf_ppo.FPDF_ImportPages(
-                              docOneWrapper.Instance,
-                              documentWrapper.Instance,
-                              null,
-                              pageCountOne) == 1;
+            for (var i = 0; i < files.Count; i++)
+            {
+                try
+                {
+                    var wrapper = new DocumentWrapper(files[i], null);
+
+                    documentWrappers.Add(wrapper);
+                }
+                catch (DocnetLoadDocumentException e)
+                {
+                    documentLoadExceptions.Add(new DocnetLoadDocumentError(i, e));
+                }
+            }
+
+            if (documentLoadExceptions.Count <= 0)
+            {
+                return documentWrappers.ToArray();
+            }
+
+            foreach (var documentWrapper in documentWrappers)
+            {
+                documentWrapper.Dispose();
+            }
+
+            throw new DocnetLoadDocumentsException("unable to open one or more documents",
+                documentLoadExceptions.ToArray());
+        }
+
+        private static byte[] Merge(IList<DocumentWrapper> docWrappers)
+        {
+            var docOneWrapper = docWrappers[0];
+            using (var stream = new MemoryStream())
+            {
+                if (docWrappers.Count > 1)
+                {
+                    for (int i = 1; i < docWrappers.Count; i++)
+                    {
+                        var documentWrapper = docWrappers[i];
+                        var pageCountOne = fpdf_view.FPDF_GetPageCount(docOneWrapper.Instance);
+
+                        var success = fpdf_ppo.FPDF_ImportPages(
+                            docOneWrapper.Instance,
+                            documentWrapper.Instance,
+                            null,
+                            pageCountOne) == 1;
+
+                        if (!success)
+                        {
+                            throw new DocnetException("failed to merge files");
+                        }
+                    }
+                }
+
+                return GetBytes(stream, docOneWrapper);
+            }
+        }
+
+        private static byte[] Merge(DocumentWrapper docOneWrapper, DocumentWrapper docTwoWrapper)
+        {
+            using (var stream = new MemoryStream())
+            {
+                var pageCountOne = fpdf_view.FPDF_GetPageCount(docOneWrapper.Instance);
+
+                var success = fpdf_ppo.FPDF_ImportPages(
+                    docOneWrapper.Instance,
+                    docTwoWrapper.Instance,
+                    null,
+                    pageCountOne) == 1;
+
+                if (!success)
+                {
+                    throw new DocnetException("failed to merge files");
+                }
+
+                return GetBytes(stream, docOneWrapper);
+            }
+        }
+
+        public byte[] Split(string filePath, int pageFromIndex, int pageToIndex)
+        {
+            lock (DocLib.Lock)
+            {
+                using (var srcWrapper = new DocumentWrapper(filePath, null))
+                {
+                    return Split(srcWrapper, pageFromIndex, pageToIndex);
+                }
+            }
+        }
+
+        public byte[] Split(byte[] bytes, int pageFromIndex, int pageToIndex)
+        {
+            lock (DocLib.Lock)
+            {
+                using (var srcWrapper = new DocumentWrapper(bytes, null))
+                {
+                    return Split(srcWrapper, pageFromIndex, pageToIndex);
+                }
+            }
+        }
+
+        public byte[] Split(string filePath, string pageRange)
+        {
+            lock (DocLib.Lock)
+            {
+                using (var srcWrapper = new DocumentWrapper(filePath, null))
+                {
+                    return Split(srcWrapper, pageRange);
+                }
+            }
+        }
+
+        public byte[] Split(byte[] bytes, string pageRange)
+        {
+            lock (DocLib.Lock)
+            {
+                using (var srcWrapper = new DocumentWrapper(bytes, null))
+                {
+                    return Split(srcWrapper, pageRange);
+                }
+            }
+        }
+
+        private static byte[] Split(DocumentWrapper srcWrapper, int pageFromIndex, int pageToIndex)
+        {
+            return Split(srcWrapper, $"{pageFromIndex + 1} - {pageToIndex + 1}");
+        }
+
+        private static byte[] Split(DocumentWrapper srcWrapper, string pageRange)
+        {
+            using (var newWrapper = new DocumentWrapper(fpdf_edit.FPDF_CreateNewDocument()))
+            using (var stream = new MemoryStream())
+            {
+                var success = fpdf_ppo.FPDF_ImportPages(
+                    newWrapper.Instance,
+                    srcWrapper.Instance,
+                    pageRange,
+                    0) == 1;
+
+                if (!success)
+                {
+                    throw new DocnetException("failed to split file");
+                }
+
+                return GetBytes(stream, newWrapper);
+            }
+        }
+
+        public byte[] Unlock(string filePath, string password)
+        {
+            lock (DocLib.Lock)
+            {
+                using (var docWrapper = new DocumentWrapper(filePath, password))
+                {
+                    return Unlock(docWrapper);
+                }
+            }
+        }
+
+        public byte[] Unlock(byte[] bytes, string password)
+        {
+            lock (DocLib.Lock)
+            {
+                using (var docWrapper = new DocumentWrapper(bytes, password))
+                {
+                    return Unlock(docWrapper);
+                }
+            }
+        }
+
+        public byte[] JpegToPdf(IReadOnlyList<JpegImage> files)
+        {
+            lock (DocLib.Lock)
+            {
+                using (var newWrapper = new DocumentWrapper(fpdf_edit.FPDF_CreateNewDocument()))
+                using (var outStream = new MemoryStream())
+                {
+                    var index = 0;
+
+                    foreach (var image in files)
+                    {
+                        using (var stream = new MemoryStream(image.Bytes))
+                        {
+                            var page = fpdf_edit.FPDFPageNew(newWrapper.Instance, index, image.Width, image.Height);
+                            var imageObj = fpdf_edit.FPDFPageObjNewImageObj(newWrapper.Instance);
+
+                            fpdf_custom_edit.FPDFImageObjLoadJpegFile(page, 1, imageObj,
+                                FileHandle.FromStream(stream, image.Bytes.Length));
+                            fpdf_edit.FPDFImageObjSetMatrix(imageObj, image.Width, 0, 0, image.Height, 0, 0);
+                            fpdf_edit.FPDFPageInsertObject(page, imageObj);
+                            fpdf_edit.FPDFPageGenerateContent(page);
+                            fpdf_view.FPDF_ClosePage(page);
+
+                            index++;
+                        }
+                    }
+
+                    return GetBytes(outStream, newWrapper);
+                }
+            }
+        }
+
+        private static byte[] Unlock(DocumentWrapper docWrapper)
+        {
+            using (var stream = new MemoryStream())
+            {
+                return GetBytes(stream, docWrapper);
+            }
+        }
+
+        private static byte[] GetBytes(MemoryStream stream, DocumentWrapper docWrapper)
+        {
+            var success = fpdf_save.FPDF_SaveAsCopy(docWrapper.Instance, stream);
 
             if (!success)
             {
-              throw new DocnetException("failed to merge files");
+                throw new DocnetException("failed to unlock the document");
             }
-          }
+
+            return stream.ToArray();
         }
-
-        return GetBytes(stream, docOneWrapper);
-      }
     }
-
-    private static byte[] Merge(DocumentWrapper docOneWrapper, DocumentWrapper docTwoWrapper)
-    {
-      using (var stream = new MemoryStream())
-      {
-        var pageCountOne = fpdf_view.FPDF_GetPageCount(docOneWrapper.Instance);
-
-        var success = fpdf_ppo.FPDF_ImportPages(
-                          docOneWrapper.Instance,
-                          docTwoWrapper.Instance,
-                          null,
-                          pageCountOne) == 1;
-
-        if (!success)
-        {
-          throw new DocnetException("failed to merge files");
-        }
-
-        return GetBytes(stream, docOneWrapper);
-      }
-    }
-
-    public byte[] Split(string filePath, int pageFromIndex, int pageToIndex)
-    {
-      lock (DocLib.Lock)
-      {
-        using (var srcWrapper = new DocumentWrapper(filePath, null))
-        {
-          return Split(srcWrapper, pageFromIndex, pageToIndex);
-        }
-      }
-    }
-
-    public byte[] Split(byte[] bytes, int pageFromIndex, int pageToIndex)
-    {
-      lock (DocLib.Lock)
-      {
-        using (var srcWrapper = new DocumentWrapper(bytes, null))
-        {
-          return Split(srcWrapper, pageFromIndex, pageToIndex);
-        }
-      }
-    }
-
-    public byte[] Split(string filePath, string pageRange)
-    {
-      lock (DocLib.Lock)
-      {
-        using (var srcWrapper = new DocumentWrapper(filePath, null))
-        {
-          return Split(srcWrapper, pageRange);
-        }
-      }
-    }
-
-    public byte[] Split(byte[] bytes, string pageRange)
-    {
-      lock (DocLib.Lock)
-      {
-        using (var srcWrapper = new DocumentWrapper(bytes, null))
-        {
-          return Split(srcWrapper, pageRange);
-        }
-      }
-    }
-
-    private static byte[] Split(DocumentWrapper srcWrapper, int pageFromIndex, int pageToIndex)
-    {
-      return Split(srcWrapper, $"{pageFromIndex + 1} - {pageToIndex + 1}");
-    }
-
-    private static byte[] Split(DocumentWrapper srcWrapper, string pageRange)
-    {
-      using (var newWrapper = new DocumentWrapper(fpdf_edit.FPDF_CreateNewDocument()))
-      using (var stream = new MemoryStream())
-      {
-        var success = fpdf_ppo.FPDF_ImportPages(
-                          newWrapper.Instance,
-                          srcWrapper.Instance,
-                          pageRange,
-                          0) == 1;
-
-        if (!success)
-        {
-          throw new DocnetException("failed to split file");
-        }
-
-        return GetBytes(stream, newWrapper);
-      }
-    }
-
-    public byte[] Unlock(string filePath, string password)
-    {
-      lock (DocLib.Lock)
-      {
-        using (var docWrapper = new DocumentWrapper(filePath, password))
-        {
-          return Unlock(docWrapper);
-        }
-      }
-    }
-
-    public byte[] Unlock(byte[] bytes, string password)
-    {
-      lock (DocLib.Lock)
-      {
-        using (var docWrapper = new DocumentWrapper(bytes, password))
-        {
-          return Unlock(docWrapper);
-        }
-      }
-    }
-
-    public byte[] JpegToPdf(IReadOnlyList<JpegImage> files)
-    {
-      lock (DocLib.Lock)
-      {
-        using (var newWrapper = new DocumentWrapper(fpdf_edit.FPDF_CreateNewDocument()))
-        using (var outStream = new MemoryStream())
-        {
-          var index = 0;
-
-          foreach (var image in files)
-          {
-            using (var stream = new MemoryStream(image.Bytes))
-            {
-              var page = fpdf_edit.FPDFPageNew(newWrapper.Instance, index, image.Width, image.Height);
-              var imageObj = fpdf_edit.FPDFPageObjNewImageObj(newWrapper.Instance);
-
-              fpdf_custom_edit.FPDFImageObjLoadJpegFile(page, 1, imageObj, FileHandle.FromStream(stream, image.Bytes.Length));
-              fpdf_edit.FPDFImageObjSetMatrix(imageObj, image.Width, 0, 0, image.Height, 0, 0);
-              fpdf_edit.FPDFPageInsertObject(page, imageObj);
-              fpdf_edit.FPDFPageGenerateContent(page);
-              fpdf_view.FPDF_ClosePage(page);
-
-              index++;
-            }
-          }
-
-          return GetBytes(outStream, newWrapper);
-        }
-      }
-    }
-
-    private static byte[] Unlock(DocumentWrapper docWrapper)
-    {
-      using (var stream = new MemoryStream())
-      {
-        return GetBytes(stream, docWrapper);
-      }
-    }
-
-    private static byte[] GetBytes(MemoryStream stream, DocumentWrapper docWrapper)
-    {
-      var success = fpdf_save.FPDF_SaveAsCopy(docWrapper.Instance, stream);
-
-      if (!success)
-      {
-        throw new DocnetException("failed to unlock the document");
-      }
-
-      return stream.ToArray();
-    }
-  }
 }


### PR DESCRIPTION
The first file is merged into an empty document to prevent an attached file coming from one of the merged PDFs, as well as inconsistent metadata.

Fixes # .
